### PR TITLE
Update CI 02 2025

### DIFF
--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -3,7 +3,7 @@ description: "Encapsulate cmake composite run steps that are common for Linux an
 # reference https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
 inputs:
   conan-compiler:
-    description: "gcc9 apple-clang"
+    description: "gcc apple-clang"
     required: true
   conan-cc:
     description: "gcc clang"

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: "g++ clang++"
     required: true
   conan-compiler-version:
-    description: "A number [gcc: 5 6 7 8 9 ] [clang: 39 40 50 60 7 8 9] [10.0]"
+    description: "A number [gcc: 5 6 7 8 9 10 11 12 13 14] [clang: 39 40 50 60 7 8 9 10 11 12 13 14 15 16 17 18 19 20] [10.0]"
     required: true
   conan-libcxx-version:
     description: "Linux: libstdc++ or Macos: libc++ "
@@ -36,7 +36,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan~=1.64.0
+        pip install conan~=1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         pip install h5py

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -3,7 +3,7 @@ description: "Encapsulate cmake composite run steps that are common for Windows,
 # reference https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
 inputs:
   conan-visual-version:
-    description: "MSVC version: 15, 16 represent msvc-2017 or msvc-2019"
+    description: "MSVC version: 16, 17 represent msvc-2019 and msvc-2022"
     required: true
   conan-visual-runtime:
     description: "MD or MDd"

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan~=1.64.0
+        pip install conan~=1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         pip install h5py

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -54,7 +54,6 @@ runs:
       run: |
         for /f "delims=" %%i in ('where cmake') do set CONAN_CMAKE_PROGRAM="%%i"
         set CONAN_USER_HOME=%cd%\_conan
-        set VS160COMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools"
 
         echo Add LKEB artifactory as remote at URL: %CONAN_UPLOAD%
         conan remote add %CONAN_LKEB_ARTIFACTORY% %CONAN_UPLOAD%

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,6 @@ jobs:
             build-runtime: MD
             build-config: Release
 
-          - name: Linux_gcc10
-            os: ubuntu-20.04
-            build-compiler: gcc
-            build-cversion: 10
-            build-config: Release
-            build-os: Linux
-            build-libcxx: libstdc++11
-
           - name: Linux_gcc11
             os: ubuntu-22.04
             build-cc: gcc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,13 @@ jobs:
             build-runtime: MD
             build-config: Release
 
+          - name: Windows-msvc2025
+            os: windows-2025
+            compiler: msvc-2022
+            build-cversion: 17
+            build-runtime: MD
+            build-config: Release
+
           - name: Linux_gcc10
             os: ubuntu-20.04
             build-compiler: gcc
@@ -67,15 +74,6 @@ jobs:
             build-os: Linux
             build-libcxx: libstdc++11
 
-          - name: Macos_xcode13.4
-            os: macos-12
-            build-compiler: apple-clang
-            build-cversion: 13
-            build-config: Release
-            build-os: Macos
-            build-xcode-version: 13.4
-            build-libcxx: libc++
-
           - name: Macos_xcode14.3
             os: macos-13
             build-compiler: apple-clang
@@ -94,9 +92,18 @@ jobs:
             build-xcode-version: 15.4
             build-libcxx: libc++
 
+          - name: Macos_xcode16
+            os: macos-15
+            build-compiler: apple-clang
+            build-cversion: 16
+            build-config: Release
+            build-os: Macos
+            build-xcode-version: 16.2
+            build-libcxx: libc++
+
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,6 @@ jobs:
             build-runtime: MD
             build-config: Release
 
-          - name: Windows-msvc2025
-            os: windows-2025
-            compiler: msvc-2022
-            build-cversion: 17
-            build-runtime: MD
-            build-config: Release
-
           - name: Linux_gcc11
             os: ubuntu-22.04
             build-cc: gcc

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path, PurePosixPath
 import subprocess
 
-required_conan_version = ">=1.62.0"
+required_conan_version = ">=1.66.0"
 
 
 class Lz4Conan(ConanFile):

--- a/conanfile.py
+++ b/conanfile.py
@@ -106,8 +106,10 @@ endif()""")
         cmake_debug.build(build_type="Debug")
 
         cmake_release = self._configure_cmake()
+        cmake_release.build(build_type="RelWithDebInfo")
+        
+        cmake_release = self._configure_cmake()
         cmake_release.build(build_type="Release")
-
 
     # Package has no build type marking
     def package_id(self):
@@ -143,6 +145,8 @@ endif()""")
         print(f"********** package dir {self.package_folder}")
         # Debug
         self._pkg_bin("Debug")
+        # RelWithDebInfo
+        self._pkg_bin("RelWithDebInfo")
         # Release
         self._pkg_bin("Release")
         # In lz4Targets.cmake th variable _IMPORT_PATH assumes that the files 


### PR DESCRIPTION
- Remove `ubuntu-20.04`
- Remove `macos-12`
- Add `macos-15` (XCode 16.2, ARM)
- Add `RelWithDebInfo` build

See https://github.com/actions/runner-images/issues/10721
> The macOS 12 Actions runner image will begin deprecation on 10/7/24 and will be fully unsupported by 12/3/24 for GitHub and by 01/13/25 for ADO

See https://github.com/actions/runner-images/issues/11101
> The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01 

Also: update conan to [1.66 which adds new apple-clang 16](https://github.com/conan-io/conan/releases/tag/1.66.0) (Otherwise adding `macos-15` (XCode 16.2) won't compile)
- **Caution**: I think this will require downstream repos (i.e. HDILib) to also upgrade their conan version